### PR TITLE
Subclass http output plugin

### DIFF
--- a/lib/logstash/outputs/loginsight.rb
+++ b/lib/logstash/outputs/loginsight.rb
@@ -20,8 +20,8 @@ class LogStash::Outputs::Loginsight < LogStash::Outputs::Http
   config :proto, :validate => :string, :default => 'https'
   config :uuid, :validate => :string, :default => nil
 
-  config :verify, :validate => :boolean, :default => true, :obsolete => 'Always verify HTTPS certificates. For self-signed certs, use openssl s_client to save server\'s certificate to a PEM-formatted file. Then pass the filename in "cacert" option.'
-  config :ca_file, :validate => :string, :default => nil, :deprecated => 'Use "cacert" instead, specify path to PEM-formatted file.'
+  config :verify, :validate => :boolean, :default => nil, :deprecated => 'Deprecated alias for "ssl_certificate_validation". Insecure. For self-signed certs, use openssl s_client to save server\'s certificate to a PEM-formatted file. Then pass the filename in "cacert" option.'
+  config :ca_file, :validate => :string, :default => nil, :deprecated => 'Deprecated alias for "cacert", specify path to PEM-formatted file.'
 
   config :flush_size, :validate => :number, :default => 1, :obsolete => 'Has no effect. Events are sent without delay.'
   config :idle_flush_time, :validate => :number, :default => 1, :obsolete => 'Has no effect. Events are sent without delay.'
@@ -51,10 +51,14 @@ class LogStash::Outputs::Loginsight < LogStash::Outputs::Http
       @cacert = @ca_file
     end
 
+    unless @verify.nil?
+      @ssl_certificate_validation = @verify
+    end
+
     # Hard-wired options
-    @http_method = "post"
-    @format = "json"
-    @content_type = "application/json"
+    @http_method = 'post'
+    @format = 'json'
+    @content_type = 'application/json'
 
     @uuid ||= ( @id or 0 )  # Default UUID
     @logger.debug("Starting up agent #{@uuid}")
@@ -63,8 +67,6 @@ class LogStash::Outputs::Loginsight < LogStash::Outputs::Http
       @url = "#{@proto}://#{@host}:#{@port}/api/v1/events/ingest/#{@uuid}"
     end
 
-
-    @logger.debug("Client", :client => @client)
     super
 
   end # def register

--- a/logstash-output-loginsight.gemspec
+++ b/logstash-output-loginsight.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-loginsight'
-  s.version       = '0.2.2'
+  s.version       = '0.3.0'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'Output events to a Log Insight server. This uses the Ingestion API protocol.'
   s.description   = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-output-loginsight. This gem is not a stand-alone program.'
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "logstash-devutils", ">= 0"#, ">= 1.3.1"
   s.add_development_dependency "rspec", ">= 0"
   s.add_development_dependency "logstash-codec-plain", ">= 0"
+  s.add_development_dependency "logstash-output-http", ">= 0"
 
 end


### PR DESCRIPTION
Instead of reimplementing wrapper for Manticore, subclass the existing logstash-output-http plugin. Take advantage of all existing features of that plugin, including retry behavior.